### PR TITLE
Feature/event keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2015-12-10
+- Emit the datastore key in inserted and updated events as well as the model
+
 ## [1.1.0] - 2015-12-09
 - Raise inserted, updated and deleted events
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Parameters:
 
 Events:
 
-* on('inserted', fn) - fn receives the inserted model
-* on('updated', fn) - fn receives the updated model
-* on('deleted', fn) - fn receives the key for the deleted model
+* on('inserted', (model, key) => {}) - emitted when a new model is successfully inserted
+* on('updated', (model, key) => {}) - emitted when an existing model is successfully updated
+* on('deleted', key => {}) - emitted when an existing model is successfully deleted
 
 ### Development
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class Model extends events.EventEmitter {
     const date = new Date();
     return save(this._dataset, key, Object.assign({_metadata: {created: date, updated: date}}, entity), 'insert')
       .then(model => {
-        this.emit('inserted', model);
+        this.emit('inserted', model, key);
         return model;
       });
   }
@@ -102,7 +102,7 @@ class Model extends events.EventEmitter {
         return save(this._dataset, key, updatedEntity, 'update');
       })
       .then(model => {
-        this.emit('updated', model);
+        this.emit('updated', model, key);
         return model;
       });
   }

--- a/tests/model_events.js
+++ b/tests/model_events.js
@@ -41,15 +41,25 @@ describe('GCloud Datastore Model Events', () => {
     });
 
     describe('when insert succeeds', () => {
+      const key = dataset.key('Thing', '1');
+
       beforeEach(() =>
-        TestModel.insert(dataset.key('Thing', '1'), {test: 'value'}).then(model => insertedModel = model));
+        TestModel.insert(key, {test: 'value'}).then(model => insertedModel = model));
 
       it('raises the event', () => {
         sinon.assert.calledOnce(onInsertedEventSpy);
       });
 
-      it('sends the model as the only event argument', () => {
-        expect(onInsertedEventSpy.firstCall.args).to.deep.equal([insertedModel]);
+      it('sends two arguments', () => {
+        expect(onInsertedEventSpy.firstCall.args).to.have.length(2);
+      });
+
+      it('sends the model as the first event argument', () => {
+        expect(onInsertedEventSpy.firstCall.args[0]).to.deep.equal(insertedModel);
+      });
+
+      it('sends the key as the second event argument', () => {
+        expect(onInsertedEventSpy.firstCall.args[1]).to.deep.equal(key);
       });
     });
 
@@ -74,15 +84,25 @@ describe('GCloud Datastore Model Events', () => {
     });
 
     describe('when update succeeds', () => {
+      const key = dataset.key('Thing', '1');
+
       beforeEach(() =>
-        TestModel.update(dataset.key('Thing', '1'), {test: 'value'}).then(model => updatedModel = model));
+        TestModel.update(key, {test: 'value'}).then(model => updatedModel = model));
 
       it('raises the event', () => {
         sinon.assert.calledOnce(onUpdatedEventSpy);
       });
 
-      it('sends the model as the only event argument', () => {
-        expect(onUpdatedEventSpy.firstCall.args).to.deep.equal([updatedModel]);
+      it('sends two arguments', () => {
+        expect(onUpdatedEventSpy.firstCall.args).to.have.length(2);
+      });
+
+      it('sends the model as the first event argument', () => {
+        expect(onUpdatedEventSpy.firstCall.args[0]).to.deep.equal(updatedModel);
+      });
+
+      it('sends the key as the second event argument', () => {
+        expect(onUpdatedEventSpy.firstCall.args[1]).to.deep.equal(key);
       });
     });
 


### PR DESCRIPTION
Emit the key as well as the model to help get information about ancestors when there is no relationship in the model data itself (i.e. no parent_id field)
